### PR TITLE
Heap profile: show incremental flamegraph

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/memory/heap_profile/callstacks.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/memory/heap_profile/callstacks.sql
@@ -27,7 +27,9 @@ RETURNS TableOrSubquery AS
         sum(size) AS self_size,
         sum(count) AS self_count,
         sum(alloc_size) AS self_alloc_size,
-        sum(alloc_count) AS self_alloc_count
+        sum(alloc_count) AS self_alloc_count,
+        sum(free_size) AS self_free_size,
+        sum(free_count) AS self_free_count
       FROM $allocations
       GROUP BY
         callsite_id
@@ -42,7 +44,9 @@ RETURNS TableOrSubquery AS
     coalesce(m.self_size, 0) AS self_size,
     coalesce(m.self_count, 0) AS self_count,
     coalesce(m.self_alloc_size, 0) AS self_alloc_size,
-    coalesce(m.self_alloc_count, 0) AS self_alloc_count
+    coalesce(m.self_alloc_count, 0) AS self_alloc_count,
+    coalesce(m.self_free_size, 0) AS self_free_size,
+    coalesce(m.self_free_count, 0) AS self_free_count
   FROM _callstacks_for_stack_profile_samples!(metrics) AS c
   LEFT JOIN metrics AS m
     USING (callsite_id)

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
@@ -191,60 +191,60 @@ function flamegraphMetrics(
     case ProfileType.NATIVE_HEAP_PROFILE:
       return flamegraphMetricsForHeapProfile(ts, upid, [
         {
-          name: 'Unreleased Malloc Size',
-          unit: 'B',
-          columnName: 'self_size',
-        },
-        {
-          name: 'Unreleased Malloc Count',
-          unit: '',
-          columnName: 'self_count',
-        },
-        {
-          name: 'Total Malloc Size',
+          name: 'Allocation Size',
           unit: 'B',
           columnName: 'self_alloc_size',
         },
         {
-          name: 'Total Malloc Count',
+          name: 'Allocation Count',
           unit: '',
           columnName: 'self_alloc_count',
+        },
+        {
+          name: 'Free Size',
+          unit: 'B',
+          columnName: 'self_free_size',
+        },
+        {
+          name: 'Free Count',
+          unit: '',
+          columnName: 'self_free_count',
         },
       ]);
     case ProfileType.HEAP_PROFILE:
       return flamegraphMetricsForHeapProfile(ts, upid, [
         {
-          name: 'Unreleased Size',
-          unit: 'B',
-          columnName: 'self_size',
-        },
-        {
-          name: 'Unreleased Count',
-          unit: '',
-          columnName: 'self_count',
-        },
-        {
-          name: 'Total Size',
+          name: 'Allocation Size',
           unit: 'B',
           columnName: 'self_alloc_size',
         },
         {
-          name: 'Total Count',
+          name: 'Allocation Count',
           unit: '',
           columnName: 'self_alloc_count',
+        },
+        {
+          name: 'Free Size',
+          unit: 'B',
+          columnName: 'self_free_size',
+        },
+        {
+          name: 'Free Count',
+          unit: '',
+          columnName: 'self_free_count',
         },
       ]);
     case ProfileType.JAVA_HEAP_SAMPLES:
       return flamegraphMetricsForHeapProfile(ts, upid, [
         {
-          name: 'Total Allocation Size',
+          name: 'Allocation Size',
           unit: 'B',
-          columnName: 'self_size',
+          columnName: 'self_alloc_size',
         },
         {
-          name: 'Total Allocation Count',
+          name: 'Allocation Count',
           unit: '',
-          columnName: 'self_count',
+          columnName: 'self_alloc_count',
         },
       ]);
     case ProfileType.MIXED_HEAP_PROFILE:
@@ -252,12 +252,22 @@ function flamegraphMetrics(
         {
           name: 'Allocation Size (malloc + java)',
           unit: 'B',
-          columnName: 'self_size',
+          columnName: 'self_alloc_size',
         },
         {
           name: 'Allocation Count (malloc + java)',
           unit: '',
-          columnName: 'self_count',
+          columnName: 'self_alloc_count',
+        },
+        {
+          name: 'Free Size (malloc + java)',
+          unit: 'B',
+          columnName: 'self_free_size',
+        },
+        {
+          name: 'Free Count (malloc + java)',
+          unit: '',
+          columnName: 'self_free_count',
         },
       ]);
     case ProfileType.JAVA_HEAP_GRAPH:
@@ -429,16 +439,20 @@ function flamegraphMetricsForHeapProfile(
           self_size,
           self_count,
           self_alloc_size,
-          self_alloc_count
+          self_alloc_count,
+          self_free_size,
+          self_free_count
         from _android_heap_profile_callstacks_for_allocations!((
           select
             callsite_id,
             size,
             count,
             max(size, 0) as alloc_size,
-            max(count, 0) as alloc_count
+            max(count, 0) as alloc_count,
+            -min(size, 0) as free_size,
+            -min(count, 0) as free_count
           from heap_profile_allocation a
-          where a.ts <= ${ts} and a.upid = ${upid}
+          where a.ts = ${ts} and a.upid = ${upid}
         ))
       )
     `,


### PR DESCRIPTION
## Summary
- Generate heap profile flamegraph using only allocations at the selected timestamp
- Include free stack metrics so allocation and release stacks are distinguishable

## Testing
- `tools/format-sources ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts src/trace_processor/perfetto_sql/stdlib/android/memory/heap_profile/callstacks.sql` (fails: Cannot find $.venv/bin/python3)
- `ui/format-sources ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts` (fails: Could not find Node.js hermetic installation)
- `ui/run-unittests` (fails: Could not find Node.js hermetic installation)
- `./tools/install-build-deps --ui` (fails: unable to access android.googlesource.com)


------
https://chatgpt.com/codex/tasks/task_e_68b6a5368d0c832baf30b7848ef5c70c